### PR TITLE
Change tag start match

### DIFF
--- a/JavaScript Riot.sublime-syntax
+++ b/JavaScript Riot.sublime-syntax
@@ -1157,7 +1157,7 @@ contexts:
           pop: true
 
   literal-riot:
-    - match: riot\.tag2?\s*\(\s*
+    - match: (riot\.)?tag2?\s*\(\s*
       set:
         - include: literal-string
         - match: '`'


### PR DESCRIPTION
Riot 3 allows you to import components individually. This means that importing riot can change from `import riot from 'riot'` to `import { tag } from 'riot'`. This change allows both `riot.tag()` as well as `tag()`